### PR TITLE
Add running status and custom options for symbols.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Plug '1478zhcy/lualine-copilot'
 require("lualine").setup {
   sections = {
     lualine_x = {
-      "copilot"
+      {
+        "copilot",
+        -- default is true.
+        show_running = true,
+        symbols = {
+          running = "🚀",
+        }
+      },
     }
   }
 }

--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -11,7 +11,13 @@ local Status = {
   None = "",
 }
 
+
+local function is_loaded()
+  return vim.g.loaded_copilot == 1
+end
+
 local function is_enabled()
+  if not is_loaded() then return false end
   if vim.fn["copilot#Enabled"]() == 1 then
     return true
   else
@@ -25,11 +31,11 @@ function M:init(options)
   self.inited = false
   self.is_enabled = is_enabled
   self.symbols = symbols
-  self.running_agent = vim.fn['copilot#RunningAgent']()
+  self.running_agent = is_loaded() and vim.fn['copilot#RunningAgent']() or nil
 end
 
 function M:copilot_status()
-  local agent = vim.fn['copilot#RunningAgent']()
+  local agent = self.running_agent or is_loaded() and vim.fn['copilot#RunningAgent']() or nil
   if not agent then return 'no agent' end
   local requests = agent.requests or {}
 

--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -1,8 +1,14 @@
 local M = require("lualine.component"):extend()
 
 local symbols = {
-  enabled = "", -- f113
-  disabled = "", -- f05e
+  enabled = " ", -- f113
+  disabled = " ", -- f05e
+  running = " "
+}
+
+local Status = {
+  Running = "running",
+  None = "",
 }
 
 local function is_enabled()
@@ -13,16 +19,37 @@ local function is_enabled()
   end
 end
 
+
 function M:init(options)
   M.super.init(self, options)
   self.inited = false
   self.is_enabled = is_enabled
   self.symbols = symbols
+  self.running_agent = vim.fn['copilot#RunningAgent']()
+end
+
+function M:copilot_status()
+  local agent = vim.fn['copilot#RunningAgent']()
+  if not agent then return 'no agent' end
+  local requests = agent.requests or {}
+
+  -- requests is dict with number as index, get status from those requests.
+  for _, req in pairs(requests) do
+    local req_status = req.status
+    if req_status == "running" then
+      return Status.Running
+    end
+  end
 end
 
 function M:update_status()
   if self.inited then
     if self.is_enabled() then
+      -- return symbols.enabled
+      local status = self:copilot_status()
+      if status == Status.Running then
+        return symbols.running
+      end
       return symbols.enabled
     else
       return symbols.disabled

--- a/lua/lualine/components/copilot.lua
+++ b/lua/lualine/components/copilot.lua
@@ -8,16 +8,16 @@ local symbols = {
 
 local Status = {
   Running = "running",
-  None = "",
+  Idle = "",
 }
 
-
-local function is_loaded()
+-- cond = M.copilot_is_loaded
+M.copilot_is_loaded = function()
   return vim.g.loaded_copilot == 1
 end
 
 local function is_enabled()
-  if not is_loaded() then return false end
+  if not M.copilot_is_loaded() then return false end
   if vim.fn["copilot#Enabled"]() == 1 then
     return true
   else
@@ -25,18 +25,20 @@ local function is_enabled()
   end
 end
 
-
 function M:init(options)
   M.super.init(self, options)
+  self.options = self.options or {}
   self.inited = false
   self.is_enabled = is_enabled
-  self.symbols = symbols
-  self.running_agent = is_loaded() and vim.fn['copilot#RunningAgent']() or nil
+  self.symbols = vim.tbl_deep_extend("keep", self.options.symbols or {}, symbols)
+  -- show copilot running status, default: true
+  self.show_running = self.options.show_running ~= false and true or false
 end
 
 function M:copilot_status()
-  local agent = self.running_agent or is_loaded() and vim.fn['copilot#RunningAgent']() or nil
-  if not agent then return 'no agent' end
+  local agent = M.copilot_is_loaded() and vim.fn['copilot#RunningAgent']() or nil
+  if not agent then return Status.Idle end
+  -- most of the time, requests is just empty dict.
   local requests = agent.requests or {}
 
   -- requests is dict with number as index, get status from those requests.
@@ -46,19 +48,20 @@ function M:copilot_status()
       return Status.Running
     end
   end
+  return Status.Idle
 end
 
 function M:update_status()
   if self.inited then
     if self.is_enabled() then
       -- return symbols.enabled
-      local status = self:copilot_status()
+      local status = not self.show_running and Status.Idle or self:copilot_status()
       if status == Status.Running then
-        return symbols.running
+        return self.symbols.running
       end
-      return symbols.enabled
+      return self.symbols.enabled
     else
-      return symbols.disabled
+      return self.symbols.disabled
     end
   else
     self.inited = true


### PR DESCRIPTION
Added following options:

- `show_running = true` -- default is true, show the running status.
- `symbols = {}` -- allow user to customize the symbols for different status.